### PR TITLE
Change bible ressource and more bible versions

### DIFF
--- a/bible_parsers/bible_parser_de.js
+++ b/bible_parsers/bible_parser_de.js
@@ -11,7 +11,7 @@ var customTrim = function(s, charlist) {
 
 function scrape(verseKey, verseFind, version, cb){
   var redis_client = redis.createClient();
-  var url = "https://www.academic-bible.com/en/online-bibles/luther-bible-1984/read-the-bible-text/bibel/text/lesen/?tx_buhbibelmodul_bibletext[scripture]=" + encodeURIComponent(verseFind);
+  var url = "https://www.academic-bible.com/en/online-bibles/luther-bible-1984/read-the-bible-text/bibel/text/lesen/?tx_buhbibelmodul_bibletext[scripture]=" + encodeURIComponent(verseFind); 
 
   redis_client.get(url, function(err, reply) {
     if (!reply){


### PR DESCRIPTION
Maybe its easier to use http://www.bibleserver.com/ instead of https://www.academic-bible.com
Usage http://www.bibleserver.com/text/{Translation}/{Bibletext} e.g. http://www.bibleserver.com/text/LUT/Johannes3,16 or http://www.bibleserver.com/text/ELB/Römer8,23-28 even umlauts are working. Also different german bible translations would be great like: ELB, SLT, NLB, HFA would be great