### PR TITLE
Replaced halfwidth semicolon in ko/2020-01/10/tmi-news.md (addresses #1221)

### DIFF
--- a/src/ko/2020-01/10/tmi-news.md
+++ b/src/ko/2020-01/10/tmi-news.md
@@ -1,5 +1,5 @@
 ---
-title:  TMI News : 재림교회의 가치를 살리는 교회
+title:  TMI News：재림교회의 가치를 살리는 교회
 date:   06/03/2020
 ---
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Have you run `node compile.js -b test -l [language] -q [quarter]`?
- [x] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `node compile.js -b test -l en -q 2018-02`.

### Description of contribution

Thank you, @Vasioky, for the correction. In fact, fullwidth semicolons do not trip our builds, and as such, I normally use them. It looks like I slipped and used a halfwidth semicolon instead. Sorry about that!