### PR TITLE
Add slash before query param to parse "today" correctly

### DIFF
--- a/web/layouts/quarterly/list.html
+++ b/web/layouts/quarterly/list.html
@@ -20,7 +20,7 @@
                             </a>
                             <a href="/{{$element.path}}" class="h5 m-0 p-0 ss-quarterlies-quarterly-title" style="">{{ $element.title }}</a>
                             <p class="p-0 mt-2 ss-quarterlies-quarterly-date text-uppercase">{{ $element.human_date }}</p>
-                            <a href="/{{$element.path}}?today" class="btn btn-outline-secondary btn-lg" role="button" aria-pressed="true">{{ $.Param (print (index (split $.Dir "/") 0) ".todaysLesson") }}</a>
+                            <a href="/{{$element.path}}/?today" class="btn btn-outline-secondary btn-lg" role="button" aria-pressed="true">{{ $.Param (print (index (split $.Dir "/") 0) ".todaysLesson") }}</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Have you run `node compile.js -b test -l [language] -q [quarter]`?
- [x] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `node compile.js -b test -l en -q 2018-02`.

### Description of contribution
<!-- Please briefly describe the contribution. If you are adding new Sabbath School content, please mention the language, lesson in this format: language_code/quarterly_id/week_number. For example, en/2018-02/01, which corresponds to first week of second quarter of 2018 in English.
 -->

#### Problem
While using [the web version of the app](https://sabbath-school.adventech.io/en/), I noticed that `Today's Lesson` button on the front page, doesn't open the current weekly lesson. The reason behind this is that the front page has a missing slash (`/`) before the query param - `?today`. When this slash is missing, the app strips `?today` query param for some reason, and the user isn't redirected to the current lesson.

#### Solution
This PR fixes this issue by simply adding a slash on `Today's Lesson` button on the main page.

#### Problem-Solution illustration
![Production-development slash fix](https://user-images.githubusercontent.com/59762579/111874446-f6e4e980-899d-11eb-9264-6f2bf4fe2fb0.gif)
