### PR TITLE
Change order of lt bible list if possible

### DIFF
--- a/config.js
+++ b/config.js
@@ -96,9 +96,9 @@ var BIBLE_PARSER_CONFIG = {
   ],
 
   "lt": [
+    "lbd-eku",
     "lit",
-    "ltb",
-    "lbd-eku"
+    "ltb"
   ],
 
   "hi": ["hhbd"],

--- a/web/config.toml
+++ b/web/config.toml
@@ -332,8 +332,8 @@ unsafe = true
 	lang = "🇸🇪 Svenska"
 
 [params.lt]
-	title = "Sabato Mokykla"
-	back = "Eik atgal"
+	title = "Sabatos Mokykla"
+	back = "Eiti atgal"
 	all = "Visos pamokos"
 	todaysLesson = "Šiandienos pamoka"
 	current = "Dabartinė pamoka"


### PR DESCRIPTION
Need to change the main Lithuanian bible, so that 'lbd-eku' would be selected by default