### PR TITLE
Memory Verse fix

### DIFF
--- a/src/en/2022-03/11/01.md
+++ b/src/en/2022-03/11/01.md
@@ -7,7 +7,7 @@ date:  03/09/2022
 Rom. 15:4, 5; Rom. 5:3–5; 1 Samuel 26; Ps. 37:1–11.
 
 > <p>Memory Text:</p>
-> “But the fruit of the Spirit is . . . longsuffering” (Gala-tians 5:22, NKJV).
+> “But the fruit of the Spirit is . . . longsuffering” (Galatians 5:22, NKJV).
 
 Scientists did an experiment with four-year-old children and marshmallows. Each child was told by a scientist that they could have a marshmallow; however, if the child waited until the scientist returned from an errand, they would be given two. Some of the children stuffed the marshmallow into their mouths the moment the scientist left; others waited. The differences were noted.
 


### PR DESCRIPTION
Fix name of Bible book in memory text

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Have you run `run.sh` or `node deploy.js -b test -l [language] -q [quarter]`?
- [ ] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `./run.sh -l en -q 2022-01` or `node deploy.js -b test -l en -q 2018-02`.

### Description of contribution
<!-- Please briefly describe the contribution. If you are adding new Sabbath School content, please mention the language and lesson in this format: language_code/quarterly_id/week_number. For example, en/2018-02/01, which corresponds to the first week of the second quarter of 2018 in English.
 -->
