### PR TITLE
Replace spaces with %20 in urls to fix audio not playing iOS

### DIFF
--- a/src/en/2023-03/audio.yml
+++ b/src/en/2023-03/audio.yml
@@ -2,229 +2,229 @@
   audio:
     - artist: Adult Bible Study Guides
       tracks:
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/003 SS Lesson 1 JULY Intro and Sabbath.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/003%20SS%20Lesson%201%20JULY%20Intro%20and%20Sabbath.mp3
           target: en/2023-03/01/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/005 SS Lesson 25 June 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/005%20SS%20Lesson%2025%20June%202023.mp3
           target: en/2023-03/01/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/006 SS Lesson 26 June 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/006%20SS%20Lesson%2026%20June%202023.mp3
           target: en/2023-03/01/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/007 SS Lesson 27 June 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/007%20SS%20Lesson%2027%20June%202023.mp3
           target: en/2023-03/01/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/008 SS Lesson 28 June 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/008%20SS%20Lesson%2028%20June%202023.mp3
           target: en/2023-03/01/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/009 SS Lesson 29 June 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/009%20SS%20Lesson%2029%20June%202023.mp3
           target: en/2023-03/01/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/010 SS Lesson 30 June 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/010%20SS%20Lesson%2030%20June%202023.mp3
           target: en/2023-03/01/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/011 SS Lesson INSIDE STORY 1 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/011%20SS%20Lesson%20INSIDE%20STORY%201%20July%202023.mp3
           target: en/2023-03/01/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/023 SS Lesson 1 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/023%20SS%20Lesson%201%20July%202023.mp3
           target: en/2023-03/02/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/024 SS Lesson 2 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/024%20SS%20Lesson%202%20July%202023.mp3
           target: en/2023-03/02/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/025 SS Lesson 3 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/025%20SS%20Lesson%203%20July%202023.mp3
           target: en/2023-03/02/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/026 SS Lesson 4 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/026%20SS%20Lesson%204%20July%202023.mp3
           target: en/2023-03/02/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/027 SS Lesson 5 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/027%20SS%20Lesson%205%20July%202023.mp3
           target: en/2023-03/02/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/028 SS Lesson 6 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/028%20SS%20Lesson%206%20July%202023.mp3
           target: en/2023-03/02/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/029 SS Lesson 7 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/029%20SS%20Lesson%207%20July%202023.mp3
           target: en/2023-03/02/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/029a SS Lesson INSIDE STORY 2 July.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/029a%20SS%20Lesson%20INSIDE%20STORY%202%20July.mp3
           target: en/2023-03/02/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/033 SS Lesson 8 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/033%20SS%20Lesson%208%20July%202023.mp3
           target: en/2023-03/03/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/034 SS Lesson 9 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/034%20SS%20Lesson%209%20July%202023.mp3
           target: en/2023-03/03/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/035 SS Lesson 10 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/035%20SS%20Lesson%2010%20July%202023.mp3
           target: en/2023-03/03/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/036 SS Lesson 11 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/036%20SS%20Lesson%2011%20July%202023.mp3
           target: en/2023-03/03/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/037 SS Lesson 12 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/037%20SS%20Lesson%2012%20July%202023.mp3
           target: en/2023-03/03/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/038 SS Lesson 13 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/038%20SS%20Lesson%2013%20July%202023.mp3
           target: en/2023-03/03/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/039 SS Lesson 14 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/039%20SS%20Lesson%2014%20July%202023.mp3
           target: en/2023-03/03/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/039a SS Lesson INSIDE STORY 3 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/039a%20SS%20Lesson%20INSIDE%20STORY%203%20July%202023.mp3
           target: en/2023-03/03/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/043 SS Lesson 15 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/043%20SS%20Lesson%2015%20July%202023.mp3
           target: en/2023-03/04/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/044 SS Lesson 16 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/044%20SS%20Lesson%2016%20July%202023.mp3
           target: en/2023-03/04/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/045 SS Lesson 17 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/045%20SS%20Lesson%2017%20July%202023.mp3
           target: en/2023-03/04/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/046 SS Lesson 18 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/046%20SS%20Lesson%2018%20July%202023.mp3
           target: en/2023-03/04/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/047 SS Lesson 19 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/047%20SS%20Lesson%2019%20July%202023.mp3
           target: en/2023-03/04/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/048 SS Lesson 20 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/048%20SS%20Lesson%2020%20July%202023.mp3
           target: en/2023-03/04/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/049 SS Lesson 21 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/049%20SS%20Lesson%2021%20July%202023.mp3
           target: en/2023-03/04/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/049a SS Lesson INSIDE STORY 4 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/049a%20SS%20Lesson%20INSIDE%20STORY%204%20July%202023.mp3
           target: en/2023-03/04/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/053 SS Lesson 22 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/053%20SS%20Lesson%2022%20July%202023.mp3
           target: en/2023-03/05/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/054 SS Lesson 23 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/054%20SS%20Lesson%2023%20July%202023.mp3
           target: en/2023-03/05/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/055 SS Lesson 24 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/055%20SS%20Lesson%2024%20July%202023.mp3
           target: en/2023-03/05/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/056 SS Lesson 25 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/056%20SS%20Lesson%2025%20July%202023.mp3
           target: en/2023-03/05/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/057 SS Lesson 26 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/057%20SS%20Lesson%2026%20July%202023.mp3
           target: en/2023-03/05/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/058 SS Lesson 27 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/058%20SS%20Lesson%2027%20July%202023.mp3
           target: en/2023-03/05/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/059 SS Lesson 28 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/059%20SS%20Lesson%2028%20July%202023.mp3
           target: en/2023-03/05/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/059a SS Lesson INSIDE STORY 5 JULY 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/059a%20SS%20Lesson%20INSIDE%20STORY%205%20JULY%202023.mp3
           target: en/2023-03/05/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/063 SS Lesson 29 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/063%20SS%20Lesson%2029%20July%202023.mp3
           target: en/2023-03/06/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/064 SS Lesson 30 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/064%20SS%20Lesson%2030%20July%202023.mp3
           target: en/2023-03/06/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/065 SS Lesson 31 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/065%20SS%20Lesson%2031%20July%202023.mp3
           target: en/2023-03/06/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/066 SS Lesson 1 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/066%20SS%20Lesson%201%20August%202023.mp3
           target: en/2023-03/06/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/067 SS Lesson 2 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/067%20SS%20Lesson%202%20August%202023.mp3
           target: en/2023-03/06/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/068 SS Lesson 3 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/068%20SS%20Lesson%203%20August%202023.mp3
           target: en/2023-03/06/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/069 SS Lesson 4 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/069%20SS%20Lesson%204%20August%202023.mp3
           target: en/2023-03/06/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/069a SS Lesson INSIDE STORY 6 July 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/069a%20SS%20Lesson%20INSIDE%20STORY%206%20July%202023.mp3
           target: en/2023-03/06/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/073 SS Lesson 5 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/073%20SS%20Lesson%205%20August%202023.mp3
           target: en/2023-03/07/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/074 SS Lesson6 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/074%20SS%20Lesson6%20August%202023%20mp3
           target: en/2023-03/07/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/075 SS Lesson 7 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/075%20SS%20Lesson%207%20August%202023.mp3
           target: en/2023-03/07/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/076 SS Lesson 8 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/076%20SS%20Lesson%208%20August%202023.mp3
           target: en/2023-03/07/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/077 SS Lesson 9 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/077%20SS%20Lesson%209%20August%202023.mp3
           target: en/2023-03/07/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/078 SS Lesson 10 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/078%20SS%20Lesson%2010%20August%202023.mp3
           target: en/2023-03/07/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/079 SS Lesson 11 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/079%20SS%20Lesson%2011%20August%202023.mp3
           target: en/2023-03/07/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/079a SS Lesson INSIDE STORY 7 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/079a%20SS%20Lesson%20INSIDE%20STORY%207%20August%202023.mp3
           target: en/2023-03/07/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/083 SS Lesson 12 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/083%20SS%20Lesson%2012%20August%202023.mp3
           target: en/2023-03/08/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/084 SS Lesson 13 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/084%20SS%20Lesson%2013%20August%202023.mp3
           target: en/2023-03/08/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/085 SS Lesson 14 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/085%20SS%20Lesson%2014%20August%202023.mp3
           target: en/2023-03/08/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/086 SS Lesson 15 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/086%20SS%20Lesson%2015%20August%202023.mp3
           target: en/2023-03/08/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/087 SS Lesson 16 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/087%20SS%20Lesson%2016%20August%202023.mp3
           target: en/2023-03/08/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/088 SS Lesson 17 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/088%20SS%20Lesson%2017%20August%202023.mp3
           target: en/2023-03/08/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/089 SS Lesson 18 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/089%20SS%20Lesson%2018%20August%202023.mp3
           target: en/2023-03/08/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/089a SS Lesson INSIDE STORY 8 AUG 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/089a%20SS%20Lesson%20INSIDE%20STORY%208%20AUG%202023.mp3
           target: en/2023-03/08/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/093 SS Lesson 19 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/093%20SS%20Lesson%2019%20August%202023.mp3
           target: en/2023-03/09/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/094 SS Lesson 20 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/094%20SS%20Lesson%2020%20August%202023.mp3
           target: en/2023-03/09/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/095 SS Lesson 21 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/095%20SS%20Lesson%2021%20August%202023.mp3
           target: en/2023-03/09/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/096 SS Lesson 22 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/096%20SS%20Lesson%2022%20August%202023.mp3
           target: en/2023-03/09/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/097 SS Lesson 23 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/097%20SS%20Lesson%2023%20August%202023.mp3
           target: en/2023-03/09/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/098 SS Lesson 24 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/098%20SS%20Lesson%2024%20August%202023.mp3
           target: en/2023-03/09/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/099 SS Lesson 25 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/099%20SS%20Lesson%2025%20August%202023.mp3
           target: en/2023-03/09/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/099a SS Lesson INSIDE STORY 9 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/099a%20SS%20Lesson%20INSIDE%20STORY%209%20August%202023.mp3
           target: en/2023-03/09/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/103 SS Lesson 26 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/103%20SS%20Lesson%2026%20August%202023.mp3
           target: en/2023-03/10/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/104 SS Lesson 27 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/104%20SS%20Lesson%2027%20August%202023.mp3
           target: en/2023-03/10/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/105 SS Lesson 28 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/105%20SS%20Lesson%2028%20August%202023.mp3
           target: en/2023-03/10/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/106 SS Lesson 29 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/106%20SS%20Lesson%2029%20August%202023.mp3
           target: en/2023-03/10/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/107 SS Lesson 30 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/107%20SS%20Lesson%2030%20August%202023.mp3
           target: en/2023-03/10/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/108 SS Lesson 31 August 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/108%20SS%20Lesson%2031%20August%202023.mp3
           target: en/2023-03/10/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/109 SS Lesson 1 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/109%20SS%20Lesson%201%20September%202023.mp3
           target: en/2023-03/10/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/109a SS Lesson INSIDE STORY 10 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/109a%20SS%20Lesson%20INSIDE%20STORY%2010%20September%202023.mp3
           target: en/2023-03/10/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/113 SS Lesson 2 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/113%20SS%20Lesson%202%20September%202023.mp3
           target: en/2023-03/11/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/114 SS Lesson 3 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/114%20SS%20Lesson%203%20September%202023.mp3
           target: en/2023-03/11/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/115 SS Lesson 4 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/115%20SS%20Lesson%204%20September%202023.mp3
           target: en/2023-03/11/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/116 SS Lesson 5 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/116%20SS%20Lesson%205%20September%202023.mp3
           target: en/2023-03/11/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/117 SS Lesson 6 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/117%20SS%20Lesson%206%20September%202023.mp3
           target: en/2023-03/11/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/118 SS Lesson 7 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/118%20SS%20Lesson%207%20September%202023.mp3
           target: en/2023-03/11/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/119 SS Lesson 8 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/119%20SS%20Lesson%208%20September%202023.mp3
           target: en/2023-03/11/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/119a SS Lesson INSIDE STORY 11 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/119a%20SS%20Lesson%20INSIDE%20STORY%2011%20September%202023.mp3
           target: en/2023-03/11/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/123 SS Lesson 9 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/123%20SS%20Lesson%209%20September%202023.mp3
           target: en/2023-03/12/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/124 SS Lesson 10 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/124%20SS%20Lesson%2010%20September%202023.mp3
           target: en/2023-03/12/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/125 SS Lesson 11 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/125%20SS%20Lesson%2011%20September%202023.mp3
           target: en/2023-03/12/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/126 SS Lesson 12 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/126%20SS%20Lesson%2012%20September%202023.mp3
           target: en/2023-03/12/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/127 SS Lesson 13 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/127%20SS%20Lesson%2013%20September%202023.mp3
           target: en/2023-03/12/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/128 SS Lesson 14 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/128%20SS%20Lesson%2014%20September%202023.mp3
           target: en/2023-03/12/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/129 SS Lesson 15 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/129%20SS%20Lesson%2015%20September%202023.mp3
           target: en/2023-03/12/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/129a SS Lesson INSIDE STORY 12 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/129a%20SS%20Lesson%20INSIDE%20STORY%2012%20September%202023.mp3
           target: en/2023-03/12/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/133 SS Lesson 16 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/133%20SS%20Lesson%2016%20September%202023.mp3
           target: en/2023-03/13/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/134 SS Lesson 17 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/134%20SS%20Lesson%2017%20September%202023.mp3
           target: en/2023-03/13/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/135 SS Lesson 18 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/135%20SS%20Lesson%2018%20September%202023.mp3
           target: en/2023-03/13/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/136 SS Lesson 19 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/136%20SS%20Lesson%2019%20September%202023.mp3
           target: en/2023-03/13/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/137 SS Lesson 20 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/137%20SS%20Lesson%2020%20September%202023.mp3
           target: en/2023-03/13/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/138 SS Lesson 21 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/138%20SS%20Lesson%2021%20September%202023.mp3
           target: en/2023-03/13/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/139 SS Lesson 22 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/139%20SS%20Lesson%2022%20September%202023.mp3
           target: en/2023-03/13/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/139a SS Lesson INSIDE STORY 13 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/139a%20SS%20Lesson%20INSIDE%20STORY%2013%20September%202023.mp3
           target: en/2023-03/13/inside-story
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/143 SS Lesson 23 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/143%20SS%20Lesson%2023%20September%202023.mp3
           target: en/2023-03/14/01
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/144 SS Lesson 24 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/144%20SS%20Lesson%2024%20September%202023.mp3
           target: en/2023-03/14/02
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/145 SS Lesson 25 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/145%20SS%20Lesson%2025%20September%202023.mp3
           target: en/2023-03/14/03
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/146 SS Lesson 26 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/146%20SS%20Lesson%2026%20September%202023.mp3
           target: en/2023-03/14/04
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/147 SS Lesson 27 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/147%20SS%20Lesson%2027%20September%202023.mp3
           target: en/2023-03/14/05
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/148 SS Lesson 28 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/148%20SS%20Lesson%2028%20September%202023.mp3
           target: en/2023-03/14/06
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/149 SS Lesson 29 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/149%20SS%20Lesson%2029%20September%202023.mp3
           target: en/2023-03/14/07
-        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/149a SS Lesson INSIDE STORY 14 September 2023.mp3
+        - src: https://sabbath-school-media-tmp.s3.amazonaws.com/audio/en/2023-03/149a%20SS%20Lesson%20INSIDE%20STORY%2014%20September%202023.mp3
           target: en/2023-03/14/inside-story
     - artist: Ellen G. White Notes
       image: misc/ellen-white-notes.png


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Have you run `run.sh` or `node deploy.js -b test -l [language] -q [quarter]`?
- [x] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `./run.sh -l en -q 2022-01` or `node deploy.js -b test -l en -q 2018-02`.

### Description of contribution
<!-- Please briefly describe the contribution. If you are adding new Sabbath School content, please mention the language and lesson in this format: language_code/quarterly_id/week_number. For example, en/2018-02/01, which corresponds to the first week of the second quarter of 2018 in English.
 -->
- Replace spaces with %20 in urls to fix audio not playing iOS
- Fixing issue #2227 
