### PR TITLE
Add action to sync stage into master automatically

### DIFF
--- a/.github/workflows/sync-stage-into-master.yml
+++ b/.github/workflows/sync-stage-into-master.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   sync-stage-into-master:
     runs-on: ubuntu-latest
+    if: github.ref_name == 'stage'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/sync-stage-into-master.yml
+++ b/.github/workflows/sync-stage-into-master.yml
@@ -1,0 +1,27 @@
+name: sync-stage-into-master
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  sync-stage-into-master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: stage
+          fetch-depth: 0
+          persist-credentials: false
+          github_token: ${{ secrets.PERSONAL_GH_TOKEN }}
+      - name: Get Status of current ref
+        id: get-status
+        uses: danieldeichfuss/get-status@v0
+        with:
+          ref: ${{ github.sha }}
+      - name: Merge stage -> master
+        if: ${{steps.get-status.outputs.all-checks-completed == 'true' &&  steps.get-status.outputs.all-checks-passed == 'true'}}
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: stage
+          target_branch: master
+          github_token: ${{ secrets.PERSONAL_GH_TOKEN }}

--- a/.github/workflows/sync-stage-into-master.yml
+++ b/.github/workflows/sync-stage-into-master.yml
@@ -4,8 +4,8 @@ on:
     - cron: '0 0 * * *'
 jobs:
   sync-stage-into-master:
-    runs-on: ubuntu-latest
     if: github.ref_name == 'stage'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Have you run `run.sh` or `node deploy.js -b test -l [language] -q [quarter]`?
- [ ] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `./run.sh -l en -q 2022-01` or `node deploy.js -b test -l en -q 2018-02`.

### Description of contribution
<!-- Please briefly describe the contribution. If you are adding new Sabbath School content, please mention the language and lesson in this format: language_code/quarterly_id/week_number. For example, en/2018-02/01, which corresponds to the first week of the second quarter of 2018 in English.
 -->

It will automatically sync stage into master every day at midnight.
It'll check the current status of this commit before merging.
It'll also check if the current branch is stage.
