### PR TITLE
Make sync-stage-into-master run 1AM and 7AM

### DIFF
--- a/.github/workflows/sync-stage-into-master.yml
+++ b/.github/workflows/sync-stage-into-master.yml
@@ -1,7 +1,7 @@
 name: sync-stage-into-master
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 1,7 * * *'
 jobs:
   sync-stage-into-master:
     if: github.ref_name == 'stage'


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Have you run `run.sh` or `node deploy.js -b test -l [language] -q [quarter]`?
- [ ] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `./run.sh -l en -q 2022-01` or `node deploy.js -b test -l en -q 2018-02`.

### Description of contribution
<!-- Please briefly describe the contribution. If you are adding new Sabbath School content, please mention the language and lesson in this format: language_code/quarterly_id/week_number. For example, en/2018-02/01, which corresponds to the first week of the second quarter of 2018 in English.
 -->
- Make sync-stage-into-master run 1AM and 7AM
