### PR TITLE
fix: fix image name in leadership lessons file

### DIFF
--- a/src/pt/2025-04-cq/02/01.md
+++ b/src/pt/2025-04-cq/02/01.md
@@ -3,7 +3,7 @@ title:  Um líder jovem
 date:   05/10/2025
 ---
 
-![](image1.png)
+![](image.png)
 
 `A partir da tirinha, do texto-chave e do título, anote suas primeiras impressões sobre o que trata a lição:`
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Have you run `run.sh` or `node deploy.js -b test -l [language] -q [quarter]`?
- [x] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `./run.sh -l en -q 2022-01` or `node deploy.js -b test -l en -q 2018-02`.

### Description of contribution
pt/2025-04-cq
The name of the image was corrected, as it was different from the image we have at the root of this week's lesson.
