### PR TITLE
feat(pt): add Alive in Jesus groups to Portuguese groups.yml

### DIFF
--- a/src/pt/groups.yml
+++ b/src/pt/groups.yml
@@ -11,3 +11,10 @@
   pt:
     name: "Edição de Portugal"
     order: 101
+  # Alive in Jesus — Vivos em Jesus
+  yaijbgtgtg:
+    name: "Vivos em Jesus. Berçário — Guia do Professor"
+    order: 850
+  zaijbgsg:
+    name: "Vivos em Jesus. Berçário — Guia do Aluno"
+    order: 851


### PR DESCRIPTION
Add AIJ Beginner Teacher Guide and Student Guide groups to prepare for Portuguese translation of Alive in Jesus curriculum.

Names use Brazilian Portuguese: 'Vivos em Jesus' (official DSA Brazil translation).

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Have you run `run.sh` or `node deploy.js -b test -l [language] -q [quarter]`?
- [ ] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `./run.sh -l en -q 2022-01` or `node deploy.js -b test -l en -q 2018-02`.

### Description of contribution
<!-- Please briefly describe the contribution. If you are adding new Sabbath School content, please mention the language and lesson in this format: language_code/quarterly_id/week_number. For example, en/2018-02/01, which corresponds to the first week of the second quarter of 2018 in English.
 -->
