### PR TITLE
Fixing /de/2026 W10 1.md

### DIFF
--- a/src/de/2026-03/10/01.md
+++ b/src/de/2026-03/10/01.md
@@ -7,7 +7,7 @@ date: 29/08/2026
 2.Korinther 3,1-9; 4,7-18; 5,11-15; Kolosser 1,19-23; Epheser 2,13-16; 2. Korinther 6,11-7,1; 2. Korinther 7
 
 > <p>Merktext</p>
-> Wir sind von allen Seiten bedrängt, aber wir ängstigen uns nicht. Uns ist bange, aber wir verzagen nicht. Wir leiden Verfolgung, aber wir werden nicht verlassen. Wir werden unterdrückt, aber wir kommen nicht um. Wir tragen allezeit das Sterben Jesu an unserm Leibe, auf dass auch das Leben      (2 Kor 4,8–10)
+> Wir sind von allen Seiten bedrängt, aber wir ängstigen uns nicht. Uns ist bange, aber wir verzagen nicht. Wir leiden Verfolgung, aber wir werden nicht verlassen. Wir werden unterdrückt, aber wir kommen nicht um. Wir tragen allezeit das Sterben Jesu an unserm Leibe, auf dass auch das Leben Jesu an unserem Leibe offenbar werde. (2 Kor 4,8–10)
 
 Letzte Woche haben wir gesehen, dass Paulus sich gegen die Vorwürfe der Unbeständigkeit und mangelnden Liebe gegenüber den Korinthern verteidigte, indem er seine Einfachheit und Aufrichtigkeit deutlich machte. Er agierte immer im besten Interesse seiner geistlichen Kinder. Er beginnt in 2. Korinther 2,12–17 einen Gedankengang, der bis 2. Korinther 7 reicht. Dabei denkt er darüber nach, wie ein authentischer Dienst für Christus aussieht. Wir können aus den Gedanken von Paulus zu diesem Thema sehr viele Lehren ziehen.
 


### PR DESCRIPTION
Updated the memory verse to include the full text of 2 Kor 4,8–10.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Have you run `run.sh` or `node deploy.js -b test -l [language] -q [quarter]`?
- [ ] Have you checked for semicolons in the titles?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

For example, `./run.sh -l en -q 2022-01` or `node deploy.js -b test -l en -q 2018-02`.

### Description of contribution
<!-- Please briefly describe the contribution. If you are adding new Sabbath School content, please mention the language and lesson in this format: language_code/quarterly_id/week_number. For example, en/2018-02/01, which corresponds to the first week of the second quarter of 2018 in English.
 -->
