### PR TITLE
fix: fail lesson verification before reporting

### DIFF
--- a/tests/verify-exit-status.test.cjs
+++ b/tests/verify-exit-status.test.cjs
@@ -1,0 +1,136 @@
+"use strict"
+
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const path = require("node:path")
+const test = require("node:test")
+const vm = require("node:vm")
+
+const verifierPath = path.join(__dirname, "..", "verify.js")
+const verifierSource = fs.readFileSync(verifierPath, "utf8")
+
+async function runVerifier({ pullRequest = false, rejectComment = false } = {}) {
+    const state = {
+        errors: [],
+        failed: [],
+        posts: 0,
+    }
+    const sandboxProcess = {
+        env: pullRequest ? { GITHUB_EVENT_PATH: "event.json" } : {},
+        exitCode: 0,
+    }
+
+    const fakeFs = {
+        pathExistsSync(file) {
+            return pullRequest && file === "event.json"
+        },
+        readFileSync(file) {
+            if (file === "event.json") {
+                return JSON.stringify({ pull_request: { number: 123 } })
+            }
+            return "start_date: 01/01/2099\n"
+        },
+    }
+
+    const fakeGlob = {
+        sync(pattern) {
+            if (pattern === "src/**/2099-01?(-cq|-er)") {
+                return ["src/en/ss/2099-01"]
+            }
+            return []
+        },
+    }
+
+    function fakeMoment(value) {
+        return {
+            add() {
+                return this
+            },
+            format() {
+                return value || "Invalid date"
+            },
+        }
+    }
+
+    function sandboxRequire(request) {
+        switch (request) {
+            case "./deploy-helper":
+                return { getCompilationQuarterValue: () => "2099-01" }
+            case "./lib/meta-marked":
+            case "meta-marked":
+                return () => ({ meta: {} })
+            case "fs-extra":
+                return fakeFs
+            case "js-yaml":
+                return { load: () => ({ start_date: "01/01/2099" }) }
+            case "./lib/glob":
+            case "glob":
+                return fakeGlob
+            case "moment":
+                return fakeMoment
+            case "axios":
+                return async () => {
+                    state.posts += 1
+                    if (rejectComment) {
+                        throw new Error("comment endpoint unavailable")
+                    }
+                }
+            case "@actions/core":
+                return {
+                    setFailed(message) {
+                        state.failed.push(message)
+                        sandboxProcess.exitCode = 1
+                    },
+                }
+            case "path":
+                return path
+            default:
+                throw new Error(`Unexpected verifier dependency: ${request}`)
+        }
+    }
+
+    const result = vm.runInNewContext(verifierSource, {
+        console: {
+            error(message) {
+                state.errors.push(String(message))
+            },
+        },
+        process: sandboxProcess,
+        require: sandboxRequire,
+    }, { filename: verifierPath })
+
+    try {
+        await result
+    } catch (error) {
+        state.evaluationError = error
+    }
+
+    state.exitCode = sandboxProcess.exitCode
+    return state
+}
+
+test("content failures return a non-zero status outside a pull request", async () => {
+    const state = await runVerifier()
+
+    assert.equal(state.errors.length, 1, "the local report should still be printed")
+    assert.equal(state.failed.length, 1, "content failure must reach the process status")
+    assert.equal(state.exitCode, 1)
+})
+
+test("comment-reporting failure cannot hide the content failure signal", async () => {
+    const state = await runVerifier({ pullRequest: true, rejectComment: true })
+
+    assert.equal(state.posts, 1)
+    assert.match(state.evaluationError?.message || "", /comment endpoint unavailable/)
+    assert.equal(state.failed.length, 1, "failure must be signalled before reporting")
+    assert.equal(state.exitCode, 1)
+})
+
+test("successful pull-request reporting signals failure exactly once", async () => {
+    const state = await runVerifier({ pullRequest: true })
+
+    assert.equal(state.posts, 1)
+    assert.equal(state.evaluationError, undefined)
+    assert.equal(state.failed.length, 1)
+    assert.equal(state.exitCode, 1)
+})

--- a/verify.js
+++ b/verify.js
@@ -138,6 +138,8 @@ let validateContent = async function () {
 
 validateContent().then(async function (){
     if (failMessages.length) {
+        core.setFailed("Ooops! Looks like you have to fix some issues before I can merge this PR");
+
         let pullRequestComment = "Ooops! Looks like you have to fix some issues before I can merge this PR\n"
         pullRequestComment += "||Error description |\n| ----------- | ----------- |"
 
@@ -159,6 +161,5 @@ validateContent().then(async function (){
             }
         });
 
-        core.setFailed("Ooops! Looks like you have to fix some issues before I can merge this PR");
     }
 })


### PR DESCRIPTION
## Root cause

The verifier marked a run failed only after optional pull-request comment delivery. Local/non-PR execution returned before setting failure, and a comment-service error could throw before the process received a failing status. Known validation errors could therefore be reported while the command still exited successfully.

## Change

Signal the validation failure before either local reporting or optional pull-request comment delivery, and add regression coverage for all three exit paths.

## Evidence

- Base: `fe492faf7433053c9f65cfd4e1ccd03197e31e7e` (`stage`)
- Regression commit: `3ff034858b35d4a99d25c8de6aee4acb5cd43090` — 1/3 introduced tests passed
- Fix commit: `74365599ac67a51b2e34c68521b56ed1cc3e48f1` — 3/3 passed on Node 16.20.2 and Node 24
- Synthetic CLI proof: red prints two validation failures and exits 0; fixed head prints the same failures and exits 1
- Syntax, diff, object-connectivity, dependency-tree, and secret checks passed
- `src`, `images`, `web`, workflows, and encrypted artifact objects are byte-identical to the base

## Scope and rollout

This PR changes `verify.js` and one synthetic regression test only. It contains no lesson, image, generated web, dependency, workflow, credential, schema, persistence, or deployment changes.

The repository currently has no lockfile, so native `npm ci` is unavailable; an ephemeral public-registry lock was used only to reproduce both supported test environments. Lockfile/toolchain and baseline dependency advisories remain separate remediation roots.

Before merge, run the hosted PR annotation/comment path and the approved production corpus with the authorized private parser package. Rollback the complete two-commit range; do not restore a successful exit status for known validation failures.