### PR TITLE
ci: remove unused changed-file shell boundary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,23 +17,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v39
-      - name: List all changed files
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file was changed"
-          done
-      - name: Get changed files and write the outputs to a JSON file
-        id: changed-files-write-output-files-json
-        uses: tj-actions/changed-files@v39
-        with:
-          json: true
-          write_output_files: true
-      - name: Verify the contents of the .github/outputs/all_changed_files.json file
-        run: |
-          cat .github/outputs/all_changed_files.json
+      - name: Validate deployment change boundary
+        run: node tests/deploy-change-boundary.test.cjs
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
@@ -100,23 +85,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v39
-      - name: List all changed files
-        run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            echo "$file was changed"
-          done
-      - name: Get changed files and write the outputs to a JSON file
-        id: changed-files-write-output-files-json
-        uses: tj-actions/changed-files@v39
-        with:
-          json: true
-          write_output_files: true
-      - name: Verify the contents of the .github/outputs/all_changed_files.json file
-        run: |
-          cat .github/outputs/all_changed_files.json
+      - name: Validate deployment change boundary
+        run: node tests/deploy-change-boundary.test.cjs
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"

--- a/tests/deploy-change-boundary.test.cjs
+++ b/tests/deploy-change-boundary.test.cjs
@@ -1,0 +1,39 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const workflowPath =
+  process.argv[2] ||
+  path.join(__dirname, "..", ".github", "workflows", "deploy.yml");
+const workflow = fs.readFileSync(workflowPath, "utf8");
+
+const forbiddenBoundaries = [
+  {
+    pattern: /tj-actions\/changed-files/i,
+    description: "the retired third-party changed-files action",
+  },
+  {
+    pattern: /steps\.changed-files\.outputs\.all_changed_files/,
+    description: "raw action output embedded in a shell run block",
+  },
+  {
+    pattern: /all_changed_files\.json/,
+    description: "an unneeded changed-filename artifact",
+  },
+];
+
+for (const boundary of forbiddenBoundaries) {
+  assert.equal(
+    boundary.pattern.test(workflow),
+    false,
+    `deploy.yml must not contain ${boundary.description}`,
+  );
+}
+
+assert.equal(
+  (workflow.match(/^  deploy(?:_v2)?:$/gm) || []).length,
+  2,
+  "the guard must cover both deployment jobs",
+);
+
+console.log("Deployment changed-file boundary is absent in both jobs.");


### PR DESCRIPTION
## What changed

- remove two unused changed-file action/output sequences from each deployment job
- run a dependency-free policy guard before deployment material is used
- add a regression test covering both `deploy` and `deploy_v2`

## Root cause

Both deployment jobs collected and printed changed-file data that no compiler, uploader, invalidation step, or downstream job consumed. One diagnostic also crossed directly from a workflow expression into a shell block. The workflow already deploys the complete generated output for matching pushes, so the minimal correction is deletion of that unused boundary plus a guard against reintroduction.

This PR contains only RC-0044. Action version pinning, workflow permissions, package reproducibility, and atomic promotion remain separate changes.

## Regression evidence

- exact base: `fe492faf7433053c9f65cfd4e1ccd03197e31e7e`
- regression commit: `525c9d38de2de8c0a81ad7b5f8eec2a57270418d` (focused test exits 1 as expected)
- fix commit: `805decbbb7f1f13d459e080abac320693bfd811e` (focused test exits 0)
- exact `js-yaml` 4.1.0 parses base, regression, and fix workflows (3/3)
- Node syntax checks pass for all 10 root scripts/tests
- `git diff --check` passes for base→regression, regression→fix, and base→fix
- regression, fix, and combined binary patches are byte-identical to the audited historical oracle
- `src`, `images`, and `web` trees are unchanged; only the workflow and regression test change
- no path or semantic overlap with draft PR #4142; a merge-tree proof is conflict-free and preserves both roots' blobs

Actionlint reports no new diagnostics. Its two existing runtime-version findings are unchanged and belong to a separate root. The full content compiler is not represented as passing because this public repository has no lockfile and the compiler requires maintainer-authorized package access.

## Data, privacy, content, and rollback

No schema, stored user data, generated artifact, translation, lesson, image, audio, video, PDF, or other rights-controlled content changes. No migration is needed. The removed output was diagnostic-only and has no recovery requirement.

If deployment automation must be rolled back for another reason, retain this deletion and guard or pause automation; do not restore the unused action/output boundary. Maintainers should privately review historical runs and credential scopes before declaring the incident aspect closed.

## Draft gates

Please keep this draft until a maintainer runs no-secret hosted policy validation and completes the private historical-run/credential-scope review. This PR does not merge, release, or deploy anything.
